### PR TITLE
Updated requirements (locustio --> locust)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto3
 botocore
-locustio
+locust


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/load-testing-sagemaker-endpoints/issues/3

*Description of changes:* Fixes `pip` install error
> Locust package has moved from 'locustio' to 'locust'. Please update your reference (or pin your version to 0.14.6 if you dont want to update to 1.0)